### PR TITLE
[FEATURE] get FE urls using EID, language layers urls, schedule clear cache

### DIFF
--- a/Classes/Backend/ToolbarItems/CloudflareToolbarItem.php
+++ b/Classes/Backend/ToolbarItems/CloudflareToolbarItem.php
@@ -280,7 +280,9 @@ class CloudflareToolbarItem implements ToolbarItemInterface
         $tceMain = GeneralUtility::makeInstance(\Causal\Cloudflare\Hooks\TCEmain::class);
         $tceMain->clearCache();
 
-        $ajaxObj->addContent('success', true);
+        if (version_compare(TYPO3_version, '8.7', '<')) {
+            $ajaxObj->addContent('success', true);
+        }
     }
 
     /**********************

--- a/Classes/Backend/ToolbarItems/CloudflareToolbarItem.php
+++ b/Classes/Backend/ToolbarItems/CloudflareToolbarItem.php
@@ -14,6 +14,7 @@ namespace Causal\Cloudflare\Backend\ToolbarItems;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Causal\Cloudflare\Utility\ConfigurationUtility;
 use TYPO3\CMS\Backend\Toolbar\ToolbarItemInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -30,12 +31,6 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
  */
 class CloudflareToolbarItem implements ToolbarItemInterface
 {
-
-    /**
-     * @var string
-     */
-    protected $extKey = 'cloudflare';
-
     /**
      * @var array
      */
@@ -51,8 +46,7 @@ class CloudflareToolbarItem implements ToolbarItemInterface
      */
     public function __construct()
     {
-        $config = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$this->extKey];
-        $this->config = $config ? unserialize($config) : [];
+        $this->config = ConfigurationUtility::getExtensionConfiguration();
         $this->cloudflareService = GeneralUtility::makeInstance(\Causal\Cloudflare\Services\CloudflareService::class, $this->config);
         $this->getLanguageService()->includeLLFile('EXT:cloudflare/Resources/Private/Language/locallang.xlf');
         $pageRenderer = $this->getPageRenderer();

--- a/Classes/Controller/DashboardController.php
+++ b/Classes/Controller/DashboardController.php
@@ -14,6 +14,7 @@ namespace Causal\Cloudflare\Controller;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Causal\Cloudflare\Utility\ConfigurationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -28,12 +29,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class DashboardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
 {
-
-    /**
-     * @var string
-     */
-    protected $extKey = 'cloudflare';
-
     /**
      * @var array
      */
@@ -56,8 +51,7 @@ class DashboardController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContro
     {
         parent::__construct();
 
-        $config = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$this->extKey];
-        $this->config = $config ? unserialize($config) : [];
+        $this->config = ConfigurationUtility::getExtensionConfiguration();
         $this->cloudflareService = GeneralUtility::makeInstance(\Causal\Cloudflare\Services\CloudflareService::class, $this->config);
 
         $domains = GeneralUtility::trimExplode(',', $this->config['domains'], true);

--- a/Classes/Domain/Model/QueueItem.php
+++ b/Classes/Domain/Model/QueueItem.php
@@ -1,0 +1,145 @@
+<?php
+namespace Causal\Cloudflare\Domain\Model;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with TYPO3 source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+/**
+ * Class QueueItem
+ * @package Causal\Cloudflare\Domain\Model
+ */
+class QueueItem extends AbstractEntity
+{
+    /**
+     * Clear cache all
+     */
+    const CLEAR_CACHE_COMMAND_ALL = 1;
+
+    /**
+     * Clear cache by cache tag
+     */
+    const CLEAR_CACHE_COMMAND_CACHE_TAG = 2;
+
+    /**
+     * Clear cache for single page
+     */
+    const CLEAR_CACHE_COMMAND_PAGE = 3;
+
+    /**
+     * Page Uid to clear cache
+     *
+     * @var int
+     */
+    protected $pageUid = 0;
+
+    /**
+     * Cache command
+     *
+     * @var int
+     */
+    protected $cacheCommand = 0;
+
+    /**
+     * Cache tag
+     *
+     * @var string
+     */
+    protected $cacheTag = '';
+
+    /**
+     * Initalize queue item
+     *
+     * @param array $params
+     */
+    public function __construct(array $params = [])
+    {
+        $this->setPropertiesFromParams($params);
+    }
+    
+    /**
+     * @return int
+     */
+    public function getPageUid()
+    {
+        return $this->pageUid;
+    }
+
+    /**
+     * @param int $pageUid
+     */
+    public function setPageUid($pageUid)
+    {
+        $this->pageUid = $pageUid;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCacheCommand()
+    {
+        return $this->cacheCommand;
+    }
+
+    /**
+     * @param int $cacheCommand
+     */
+    public function setCacheCommand($cacheCommand)
+    {
+        $this->cacheCommand = $cacheCommand;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCacheTag()
+    {
+        return $this->cacheTag;
+    }
+
+    /**
+     * @param string $cacheTag
+     */
+    public function setCacheTag($cacheTag)
+    {
+        $this->cacheTag = $cacheTag;
+    }
+
+    /**
+     * Convert params from clear cache hook to obejct properties
+     *
+     * @param array $params
+     */
+    protected function setPropertiesFromParams(array $params)
+    {
+        if (!isset($params['cacheCmd'])) {
+            if ($params['table'] === 'pages') {
+                $this->setCacheCommand(self::CLEAR_CACHE_COMMAND_CACHE_TAG);
+                $this->setCacheTag('pageId_' . (int)$params['uid']);
+            }
+        } elseif (GeneralUtility::inList('all,pages', $params['cacheCmd'])) {
+            $this->setCacheCommand(self::CLEAR_CACHE_COMMAND_ALL);
+        } else {
+            if (strpos(strtolower($params['cacheCmd']), 'cachetag:') !== false) {
+                $cacheTag = substr($params['cacheCmd'], 9);
+                $this->setCacheCommand(self::CLEAR_CACHE_COMMAND_CACHE_TAG);
+                $this->setCacheTag($cacheTag);
+            } else {
+                $this->setCacheCommand(self::CLEAR_CACHE_COMMAND_PAGE);
+                $this->setPageUid((int)$params['cacheCmd']);
+            }
+        }
+    }
+}

--- a/Classes/Domain/Model/QueueItem.php
+++ b/Classes/Domain/Model/QueueItem.php
@@ -14,6 +14,7 @@ namespace Causal\Cloudflare\Domain\Model;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Causal\Cloudflare\Utility\ConfigurationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
@@ -115,6 +116,18 @@ class QueueItem extends AbstractEntity
     public function setCacheTag($cacheTag)
     {
         $this->cacheTag = $cacheTag;
+    }
+
+    /**
+     * Check if it's valid queue item
+     *
+     * @return bool
+     */
+    public function isValid()
+    {
+        return $this->getCacheCommand() === self::CLEAR_CACHE_COMMAND_ALL
+            || ConfigurationUtility::isEnablePurgeByTags() && $this->getCacheCommand() === self::CLEAR_CACHE_COMMAND_CACHE_TAG && !empty($this->getCacheTag())
+            || ConfigurationUtility::isEnablePurgeByUrl() && $this->getCacheCommand() === self::CLEAR_CACHE_COMMAND_PAGE && $this->getPageUid() !== 0;
     }
 
     /**

--- a/Classes/Domain/Model/QueueItem.php
+++ b/Classes/Domain/Model/QueueItem.php
@@ -15,6 +15,7 @@ namespace Causal\Cloudflare\Domain\Model;
  */
 
 use Causal\Cloudflare\Utility\ConfigurationUtility;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
@@ -141,6 +142,17 @@ class QueueItem extends AbstractEntity
             if ($params['table'] === 'pages') {
                 $this->setCacheCommand(self::CLEAR_CACHE_COMMAND_CACHE_TAG);
                 $this->setCacheTag('pageId_' . (int)$params['uid']);
+            } elseif (isset($params['uid_page']) && ($pageUid = (int)$params['uid_page'])) {
+                // If content was update on page and it's standard page
+                $pageRecord = BackendUtility::getRecord(
+                    'pages',
+                    $pageUid,
+                    'doktype'
+                );
+                if (is_array($pageRecord) && (int)$pageRecord['doktype'] === 1) {
+                    $this->setCacheCommand(self::CLEAR_CACHE_COMMAND_PAGE);
+                    $this->setPageUid($pageUid);
+                }
             }
         } elseif (GeneralUtility::inList('all,pages', $params['cacheCmd'])) {
             $this->setCacheCommand(self::CLEAR_CACHE_COMMAND_ALL);

--- a/Classes/Domain/Repository/QueueItemRepository.php
+++ b/Classes/Domain/Repository/QueueItemRepository.php
@@ -1,0 +1,47 @@
+<?php
+namespace Causal\Cloudflare\Domain\Repository;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with TYPO3 source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Causal\Cloudflare\Domain\Model\QueueItem;
+use TYPO3\CMS\Core\Database\DatabaseConnection;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+/**
+ * Class QueueItemRepository
+ * @package Causal\Cloudflare\Domain\Repository
+ */
+class QueueItemRepository extends Repository
+{
+    /**
+     * Create own save function
+     *
+     * @param QueueItem $queueItem
+     */
+    public function add($queueItem)
+    {
+        /** @var DatabaseConnection $db */
+        $db = $GLOBALS['TYPO3_DB'];
+
+        $db->exec_INSERTquery(
+            'tx_cloudflare_domain_model_queueitem',
+            [
+                'crdate' => time(),
+                'page_uid' => $queueItem->getPageUid(),
+                'cache_command' => $queueItem->getCacheCommand(),
+                'cache_tag' => $queueItem->getCacheTag(),
+            ]
+        );
+    }
+}

--- a/Classes/Domain/Repository/QueueItemRepository.php
+++ b/Classes/Domain/Repository/QueueItemRepository.php
@@ -16,6 +16,7 @@ namespace Causal\Cloudflare\Domain\Repository;
 
 use Causal\Cloudflare\Domain\Model\QueueItem;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
+use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
@@ -25,6 +26,14 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  */
 class QueueItemRepository extends Repository
 {
+    public function initializeObject() {
+        /** @var Typo3QuerySettings $defaultQuerySettings */
+        $defaultQuerySettings = $this->objectManager->get(Typo3QuerySettings::class);
+        // disable storage
+        $defaultQuerySettings->setRespectStoragePage(false);
+        $this->setDefaultQuerySettings($defaultQuerySettings);
+    }
+
     /**
      * Create own save function
      *

--- a/Classes/Domain/Repository/QueueItemRepository.php
+++ b/Classes/Domain/Repository/QueueItemRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Causal\Cloudflare\Domain\Repository;
 
 /*
@@ -26,7 +27,11 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  */
 class QueueItemRepository extends Repository
 {
-    public function initializeObject() {
+    /**
+     * Disable storage by default
+     */
+    public function initializeObject()
+    {
         /** @var Typo3QuerySettings $defaultQuerySettings */
         $defaultQuerySettings = $this->objectManager->get(Typo3QuerySettings::class);
         // disable storage

--- a/Classes/Eid/LinkGeneratorEid.php
+++ b/Classes/Eid/LinkGeneratorEid.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with TYPO3 source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+
+if (\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('REMOTE_ADDR') != $_SERVER['SERVER_ADDR']) {
+    header('HTTP/1.0 403 Access denied');
+    // Empty output!!!
+} else {
+    /** @var \Causal\Cloudflare\Services\PagePathResolverService $pagePathResolverService */
+    $pagePathResolverService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        \Causal\Cloudflare\Services\PagePathResolverService::class
+    );
+
+    header('Content-Type: application/json');
+    echo $pagePathResolverService->getLinks();
+}

--- a/Classes/Eid/LinkGeneratorEid.php
+++ b/Classes/Eid/LinkGeneratorEid.php
@@ -13,16 +13,10 @@
  * The TYPO3 project - inspiring people to share!
  */
 
+/** @var \Causal\Cloudflare\Services\PagePathResolverService $pagePathResolverService */
+$pagePathResolverService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+    \Causal\Cloudflare\Services\PagePathResolverService::class
+);
 
-if (\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('REMOTE_ADDR') != $_SERVER['SERVER_ADDR']) {
-    header('HTTP/1.0 403 Access denied');
-    // Empty output!!!
-} else {
-    /** @var \Causal\Cloudflare\Services\PagePathResolverService $pagePathResolverService */
-    $pagePathResolverService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-        \Causal\Cloudflare\Services\PagePathResolverService::class
-    );
-
-    header('Content-Type: application/json');
-    echo $pagePathResolverService->getLinks();
-}
+header('Content-Type: application/json');
+echo $pagePathResolverService->getLinks();

--- a/Classes/ExtDirect/ToolbarMenu.php
+++ b/Classes/ExtDirect/ToolbarMenu.php
@@ -14,6 +14,7 @@ namespace Causal\Cloudflare\ExtDirect;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Causal\Cloudflare\Utility\ConfigurationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Backend\Utility\IconUtility;
 
@@ -29,10 +30,6 @@ use TYPO3\CMS\Backend\Utility\IconUtility;
  */
 class ToolbarMenu
 {
-
-    /** @var string */
-    protected $extKey = 'cloudflare';
-
     /** @var array */
     protected $config;
 
@@ -41,8 +38,7 @@ class ToolbarMenu
      */
     public function __construct()
     {
-        $config = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$this->extKey];
-        $this->config = $config ? unserialize($config) : [];
+        $this->config = ConfigurationUtility::getExtensionConfiguration();
         $this->getLanguageService()->includeLLFile('EXT:cloudflare/Resources/Private/Language/locallang.xlf');
     }
 

--- a/Classes/ExtensionManager/Configuration.php
+++ b/Classes/ExtensionManager/Configuration.php
@@ -14,6 +14,7 @@ namespace Causal\Cloudflare\ExtensionManager;
  * The TYPO3 project - inspiring people to share!
  */
 
+use Causal\Cloudflare\Utility\ConfigurationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -28,17 +29,12 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class Configuration
 {
-
-    /** @var string */
-    protected $extKey = 'cloudflare';
-
     /**
      * Default constructor.
      */
     public function __construct()
     {
-        $config = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$this->extKey];
-        $this->config = $config ? unserialize($config) : [];
+        $this->config = ConfigurationUtility::getExtensionConfiguration();
     }
 
     /**
@@ -149,7 +145,7 @@ JS;
      */
     protected function sL($key)
     {
-        $message = $this->getLanguageService()->sL('LLL:EXT:' . $this->extKey . '/Resources/Private/Language/locallang_db.xlf:' . $key);
+        $message = $this->getLanguageService()->sL('LLL:EXT:' . ConfigurationUtility::EXT_KEY . '/Resources/Private/Language/locallang_db.xlf:' . $key);
         return $message;
     }
 

--- a/Classes/Hooks/TCEmain.php
+++ b/Classes/Hooks/TCEmain.php
@@ -71,8 +71,12 @@ class TCEmain
         /** @var QueueItem $queueItem */
         $queueItem = GeneralUtility::makeInstance(QueueItem::class, $params);
 
+        if (!$queueItem->isValid()) {
+            return;
+        }
+
         if (ConfigurationUtility::isFlyMode()) {
-            $this->clearCacheService->clearCache($queueItem);
+            $this->clearCacheService->clearSingleItemCache($queueItem);
         } else {
             $this->queueItemRepository->add($queueItem);
         }

--- a/Classes/Hooks/TCEmain.php
+++ b/Classes/Hooks/TCEmain.php
@@ -14,9 +14,10 @@ namespace Causal\Cloudflare\Hooks;
  * The TYPO3 project - inspiring people to share!
  */
 
-use Causal\Cloudflare\Services\CloudflareService;
+use Causal\Cloudflare\Services\ClearCacheService;
+use Causal\Cloudflare\Utility\ConfigurationUtility;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Authentication\AbstractUserAuthentication;
 
 /**
  * Hook for clearing cache on Cloudflare.
@@ -30,72 +31,38 @@ use TYPO3\CMS\Core\Authentication\AbstractUserAuthentication;
  */
 class TCEmain
 {
-
-    /** @var string */
-    protected $extKey = 'cloudflare';
-
-    /** @var array */
-    protected $config;
+    /**
+     * @var ClearCacheService
+     */
+    protected $clearCacheService = null;
 
     /**
      * Default constructor.
      */
     public function __construct()
     {
-        $config = $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$this->extKey];
-        $this->config = $config ? unserialize($config) : [];
+        $this->clearCacheService = GeneralUtility::makeInstance(
+            ClearCacheService::class,
+            ConfigurationUtility::getExtensionConfiguration(),
+            $GLOBALS['BE_USER']
+        );
     }
 
     /**
      * Hooks into the "clear all caches" call.
      *
      * @param array $params
-     * @param \TYPO3\CMS\Core\DataHandling\DataHandler $pObj
+     * @param DataHandler $pObj
      * @return void
      */
-    public function clear_cacheCmd(array $params, \TYPO3\CMS\Core\DataHandling\DataHandler $pObj)
+    public function clear_cacheCmd(array $params, DataHandler $pObj)
     {
-        static $handledPageUids = [];
-        static $handledTags = [];
-
-        $enablePurgeByUrl = isset($this->config['enablePurgeSingleFile']) && (bool)$this->config['enablePurgeSingleFile'];
-        $enablePurgeByTags = isset($this->config['enablePurgeByTags']) && (bool)$this->config['enablePurgeByTags'];
-
-        if (!isset($params['cacheCmd'])) {
-            if ($params['table'] === 'pages' && $enablePurgeByTags) {
-                $this->purgeIndividualFileByCacheTag(
-                    isset($GLOBALS['BE_USER']) ? $GLOBALS['BE_USER'] : null,
-                    'pageId_' . (int)$params['uid']
-                );
-            }
-            return;
-        }
-
-        if (GeneralUtility::inList('all,pages', $params['cacheCmd'])) {
-            $this->clearCloudflareCache($pObj->BE_USER);
+        if (ConfigurationUtility::isFlyMode()) {
+            $this->clearCacheService->clearCache($params);
         } else {
-            if (strpos(strtolower($params['cacheCmd']), 'cachetag:') !== false && $enablePurgeByTags) {
-                $cacheTag = substr($params['cacheCmd'], 9);
-                if (!in_array($cacheTag, $handledTags)) {
-                    $handledTags[] = $cacheTag;
-                    $this->purgeIndividualFileByCacheTag(
-                        isset($GLOBALS['BE_USER']) ? $GLOBALS['BE_USER'] : null,
-                        $cacheTag
-                    );
-                }
-            } elseif ($enablePurgeByUrl) {
-                $pageUid = (int)$params['cacheCmd'];
-                if ($pageUid && !in_array($pageUid, $handledPageUids)) {
-                    $handledPageUids[] = $pageUid;
-                    $url = $this->getFrontendUrl($pageUid);
-                    if ($url) {
-                        $this->purgeIndividualFileByUrl(
-                            isset($GLOBALS['BE_USER']) ? $GLOBALS['BE_USER'] : null,
-                            $url
-                        );
-                    }
-                }
-            }
+            /**
+             * @TODO implement enqueue
+             */
         }
     }
 
@@ -109,255 +76,11 @@ class TCEmain
         if (!isset($GLOBALS['BE_USER'])) {
             return;
         }
-        if ($GLOBALS['BE_USER']->isAdmin() || $GLOBALS['BE_USER']->getTSConfigVal('options.clearCache.all') || $GLOBALS['BE_USER']->getTSConfigVal('options.clearCache.cloudflare')) {
-            $this->clearCloudflareCache($GLOBALS['BE_USER']);
-        }
-    }
-
-    /**
-     * Clears the Cloudflare cache.
-     *
-     * @param AbstractUserAuthentication $beUser
-     * @return void
-     */
-    protected function clearCloudflareCache(AbstractUserAuthentication $beUser = null)
-    {
-        $domains = $this->config['domains'] ? GeneralUtility::trimExplode(',', $this->config['domains'], true) : [];
-
-        /** @var CloudflareService $cloudflareService */
-        $cloudflareService = GeneralUtility::makeInstance(CloudflareService::class, $this->config);
-
-        foreach ($domains as $domain) {
-            try {
-                list($identifier, $zoneName) = explode('|', $domain, 2);
-                $ret = $cloudflareService->send('/zones/' . $identifier . '/purge_cache', [
-                    'purge_everything' => true,
-                ], 'DELETE');
-                if (!is_array($ret)) {
-                    $ret = [
-                        'success' => false,
-                        'errors' => []
-                    ];
-                }
-
-                if ($beUser !== null) {
-                    if ($ret['success']) {
-                        $beUser->writelog(4, 1, 0, 0, 'User %s cleared the cache on Cloudflare (domain: "%s")', [$beUser->user['username'], $zoneName]);
-                    } else {
-                        $beUser->writelog(4, 1, 1, 0, 'User %s failed to clear the cache on Cloudflare (domain: "%s"): %s', [$beUser->user['username'], $zoneName, implode(LF, $ret['errors'])]);
-                    }
-                }
-            } catch (\RuntimeException $e) {
-                if ($beUser !== null) {
-                    $beUser->writelog(4, 1, 1, 0, $e->getMessage(), []);
-                }
-            }
-        }
-    }
-
-    /**
-     * Returns a Frontend URL corresponding to a given page UID.
-     * Implementation was inspired by EXT:vara_feurlfrombe
-     *
-     * @param integer $uid
-     * @return string
-     * @todo Add support for multiple Frontend URLs
-     */
-    protected function getFrontendUrl($uid)
-    {
-        if (isset($GLOBALS['BE_USER']) && $GLOBALS['BE_USER']->workspace != 0) {
-            // Preview in workspaces is not supported!
-            return null;
-        }
-
-        /** @var \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $tsfe */
-        $tsfe = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-            \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::class,
-            $GLOBALS['TYPO3_CONF_VARS'],
-            $uid,
-            ''
-        );
-        $GLOBALS['TSFE'] = $tsfe;
-
-        $GLOBALS['TT'] = GeneralUtility::makeInstance(\TYPO3\CMS\Core\TimeTracker\TimeTracker::class);
-        $GLOBALS['TT']->start();
-        $GLOBALS['TSFE']->config['config']['language'] = 'default';
-
-        // Fire all the required function to get the TYPO3 Frontend all set up
-        $GLOBALS['TSFE']->id = $uid;
-        $GLOBALS['TSFE']->connectToDB();
-
-        // Prevent database debug messages from messing up the output
-        $GLOBALS['TYPO3_DB']->debugOutput = false;
-
-        $GLOBALS['TSFE']->initLLVars();
-        $GLOBALS['TSFE']->initFEuser();
-
-        // Look up the page
-        $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Page\PageRepository::class);
-        $GLOBALS['TSFE']->sys_page->init($GLOBALS['TSFE']->showHiddenPage);
-
-        // If the page is not found (if the page is a sysfolder, etc), then return no URL,
-        // preventing any further processing which would result in an error page.
-        $page = $GLOBALS['TSFE']->sys_page->getPage($uid);
-
-        if (empty($page)) {
-            return null;
-        }
-
-        // If the page is a shortcut, look up the page to which the shortcut references,
-        // and do the same check as above.
-        if ($page['doktype'] == 4 && count($GLOBALS['TSFE']->getPageShortcut($page['shortcut'], $page['shortcut_mode'], $page['uid'])) == 0) {
-            return null;
-        }
-
-        // Spacer pages and sysfolders result in a page not found page too...
-        if ($page['doktype'] == 199 || $page['doktype'] == 254) {
-            return null;
-        }
-
-        $GLOBALS['TSFE']->getPageAndRootline();
-        $GLOBALS['TSFE']->initTemplate();
-        $GLOBALS['TSFE']->forceTemplateParsing = 1;
-
-        // Find the root template
-        $GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
-
-        // Fill the pSetup from the same variables from the same location as where
-        // tslib_fe->getConfigArray will get them, so they can be checked before
-        // this function is called
-        //$GLOBALS['TSFE']->sPre = $GLOBALS['TSFE']->tmpl->setup['types.'][$GLOBALS['TSFE']->type];    // toplevel - objArrayName
-        //$GLOBALS['TSFE']->pSetup = $GLOBALS['TSFE']->tmpl->setup[$GLOBALS['TSFE']->sPre . '.'];
-
-        // If there is no root template found, there is no point in continuing which would
-        // result in a 'template not found' page and then call exit PHP.
-        // And the same applies if pSetup is empty, which would result in a
-        // "The page is not configured" message.
-        if (!$GLOBALS['TSFE']->tmpl->loaded || ($GLOBALS['TSFE']->tmpl->loaded && !$GLOBALS['TSFE']->pSetup)) {
-            //return null;
-        }
-
-        $GLOBALS['TSFE']->checkAlternativeIdMethods();
-        $GLOBALS['TSFE']->determineId();
-        try {
-            $GLOBALS['TSFE']->getConfigArray();
-        } catch (\Exception $e) {
-            // Typicall problem: #1294587218: No TypoScript template found!
-            return null;
-        }
-
-        // Get linkVars, absRefPrefix, etc
-        \TYPO3\CMS\Frontend\Page\PageGenerator::pagegenInit();
-
-        /** @var $contentObj \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer */
-        $contentObj = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
-        $contentObj->start([], '');
-
-        // Create the URL
-        $link = $contentObj->typolink('', [
-            'parameter' => $uid,
-            'forceAbsoluteUrl' => 1,
-        ]);
-        $url = $contentObj->lastTypoLinkUrl;
-
-        return $url;
-    }
-
-    /**
-     * Granularly removes an individual file from Cloudflare's cache by specifying the URL.
-     *
-     * @param AbstractUserAuthentication $beUser
-     * @param string $url
-     * @return void
-     */
-    protected function purgeIndividualFileByUrl(AbstractUserAuthentication $beUser = null, $url)
-    {
-        $domains = $this->config['domains'] ? GeneralUtility::trimExplode(',', $this->config['domains'], true) : [];
-
-        $domain = null;
-        $zoneIdentifier = null;
-
-        if (preg_match('#^https?://([^/]+)#', $url, $matches)) {
-            $domainParts = explode('.', $matches[1]);
-            if (count($domainParts) > 1) {
-                $size = count($domainParts);
-                $zoneName = $domainParts[$size - 2] . '.' . $domainParts[$size - 1];
-
-                foreach ($domains as $domain) {
-                    list($identifier, $z) = explode('|', $domain, 2);
-                    if ($z === $zoneName) {
-                        $zoneIdentifier = $identifier;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if ($zoneIdentifier === null) {
-            return;
-        }
-
-        /** @var CloudflareService $cloudflareService */
-        $cloudflareService = GeneralUtility::makeInstance(CloudflareService::class, $this->config);
-
-        try {
-            $ret = $cloudflareService->send('/zones/' . $zoneIdentifier . '/purge_cache', [
-                'files' => [$url],
-            ], 'DELETE');
-
-            if ($beUser !== null) {
-                if ($ret['result'] === 'error') {
-                    $beUser->writelog(4, 1, 1, 0, 'User %s failed to clear the cache on Cloudflare (domain: "%s") for "%s": %s', [$beUser->user['username'], $domain, $url, $ret['msg']]);
-                } else {
-                    $beUser->writelog(4, 1, 0, 0, 'User %s cleared the cache on Cloudflare (domain: "%s") for "%s"', [$beUser->user['username'], $domain, $url]);
-                }
-            }
-        } catch (\RuntimeException $e) {
-            if ($beUser !== null) {
-                $beUser->writelog(4, 1, 1, 0, $e->getMessage(), []);
-            }
-        }
-    }
-
-    /**
-     * Granularly removes an individual file from Cloudflare's cache by specifying the associated Cache-Tag.
-     *
-     * @param AbstractUserAuthentication|null $beUser
-     * @param string $cacheTag
-     * @return void
-     */
-    protected function purgeIndividualFileByCacheTag(AbstractUserAuthentication $beUser = null, $cacheTag)
-    {
-        $domains = $this->config['domains'] ? GeneralUtility::trimExplode(',', $this->config['domains'], true) : [];
-
-        /** @var CloudflareService $cloudflareService */
-        $cloudflareService = GeneralUtility::makeInstance(CloudflareService::class, $this->config);
-
-        foreach ($domains as $domain) {
-            try {
-                list($identifier, $zoneName) = explode('|', $domain, 2);
-                $ret = $cloudflareService->send('/zones/' . $identifier . '/purge_cache', [
-                    'tags' => [$cacheTag],
-                ], 'DELETE');
-                if (!is_array($ret)) {
-                    $ret = [
-                        'success' => false,
-                        'errors' => []
-                    ];
-                }
-
-                if ($beUser !== null) {
-                    if ($ret['success']) {
-                        $beUser->writelog(4, 1, 0, 0, 'User %s cleared the cache on Cloudflare using Cache-Tag (domain: "%s")', [$beUser->user['username'], $zoneName]);
-                    } else {
-                        $beUser->writelog(4, 1, 1, 0, 'User %s failed to clear the cache on Cloudflare using Cache-Tag (domain: "%s"): %s', [$beUser->user['username'], $zoneName, implode(LF, $ret['errors'])]);
-                    }
-                }
-            } catch (\RuntimeException $e) {
-                if ($beUser !== null) {
-                    $beUser->writelog(4, 1, 1, 0, $e->getMessage(), []);
-                }
-            }
+        if ($GLOBALS['BE_USER']->isAdmin()
+            || $GLOBALS['BE_USER']->getTSConfigVal('options.clearCache.all')
+            || $GLOBALS['BE_USER']->getTSConfigVal('options.clearCache.cloudflare')
+        ) {
+            $this->clearCacheService->clearCloudflareCache();
         }
     }
 }

--- a/Classes/Hooks/TypoLinkPostProcessor.php
+++ b/Classes/Hooks/TypoLinkPostProcessor.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Causal\Cloudflare\Hooks;
+
+use Causal\Cloudflare\Solr\AbstractDataUrlModifier;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * Class TypoLinkPostProcessor
+ * @package Causal\Cloudflare\Hooks
+ */
+class TypoLinkPostProcessor
+{
+    /**
+     * @var TypoScriptFrontendController
+     */
+    protected $tsfe = null;
+
+    public function __construct()
+    {
+        $this->tsfe = $GLOBALS['TSFE'];
+    }
+
+    /**
+     * Modify last typolink if it's solr request and requested page is shortcut
+     * @param array $params
+     * @param ContentObjectRenderer $pObj
+     */
+    public function processTypoLink(array $params, ContentObjectRenderer $pObj)
+    {
+        // If it's getting link on it self
+        // Also this hook is called only on
+        if (isset($_GET[AbstractDataUrlModifier::GET_PARAM_NAME])
+            && isset($_SERVER['HTTP_X_TX_SOLR_IQ'])
+            && ((int)$params['parameter'] === (int)$this->tsfe->page['uid'])
+        ) {
+            $urlInfo = parse_url($pObj->lastTypoLinkUrl);
+            $pObj->lastTypoLinkUrl = sprintf(
+                '%s%s%s=%s',
+                $pObj->lastTypoLinkUrl,
+                empty($urlInfo['query']) ? '?' : '&',
+                AbstractDataUrlModifier::GET_PARAM_NAME,
+                $_GET[AbstractDataUrlModifier::GET_PARAM_NAME]
+            );
+        }
+    }
+}

--- a/Classes/Hooks/TypoLinkPostProcessor.php
+++ b/Classes/Hooks/TypoLinkPostProcessor.php
@@ -33,7 +33,7 @@ class TypoLinkPostProcessor
         // Also this hook is called only on
         if (isset($_GET[AbstractDataUrlModifier::GET_PARAM_NAME])
             && isset($_SERVER['HTTP_X_TX_SOLR_IQ'])
-            && ((int)$params['parameter'] === (int)$this->tsfe->page['uid'])
+            && ((int)$params['conf']['parameter'] === (int)$this->tsfe->page['uid'])
         ) {
             $urlInfo = parse_url($pObj->lastTypoLinkUrl);
             $pObj->lastTypoLinkUrl = sprintf(

--- a/Classes/Services/ClearCacheService.php
+++ b/Classes/Services/ClearCacheService.php
@@ -1,0 +1,362 @@
+<?php
+
+namespace Causal\Cloudflare\Services;
+
+use Causal\Cloudflare\Utility\ConfigurationUtility;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Authentication\AbstractUserAuthentication;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with TYPO3 source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Class ClearCacheService
+ * @package Causal\Cloudflare\Services
+ */
+class ClearCacheService
+{
+    /**
+     * Limit to clear cache at once
+     */
+    const CLEAR_CACHE_URLS_LIMIT = 30;
+
+    /**
+     * Settings
+     *
+     * @var array
+     */
+    protected $config = [];
+
+    /**
+     * CDN domains
+     *
+     * @var array
+     */
+    protected $domains = [];
+
+    /**
+     * @var AbstractUserAuthentication
+     */
+    protected $beUser = null;
+
+    /**
+     * Initalize
+     *
+     * @param array $config
+     * @param AbstractUserAuthentication|null $beUser
+     */
+    public function __construct(array $config, AbstractUserAuthentication $beUser = null)
+    {
+        $this->config = $config;
+        $this->beUser = $beUser;
+        if ($this->config['domains']) {
+            $this->domains = GeneralUtility::trimExplode(',', $this->config['domains'], true);
+        }
+    }
+
+    /**
+     * Main clear cache function
+     *
+     * @param array $params
+     */
+    public function clearCache(array $params)
+    {
+        static $handledPageUids = [];
+        static $handledTags = [];
+
+        $enablePurgeByUrl = isset($this->config['enablePurgeSingleFile'])
+            && (bool)$this->config['enablePurgeSingleFile'];
+        $enablePurgeByTags = isset($this->config['enablePurgeByTags']) && (bool)$this->config['enablePurgeByTags'];
+
+        if (!isset($params['cacheCmd'])) {
+            if ($params['table'] === 'pages' && $enablePurgeByTags) {
+                $this->purgeIndividualFilesByCacheTag(
+                    ['pageId_' . (int)$params['uid']]
+                );
+            }
+            return;
+        }
+
+        if (GeneralUtility::inList('all,pages', $params['cacheCmd'])) {
+            $this->clearCloudflareCache();
+        } else {
+            if (strpos(strtolower($params['cacheCmd']), 'cachetag:') !== false && $enablePurgeByTags) {
+                $cacheTag = substr($params['cacheCmd'], 9);
+                if (!in_array($cacheTag, $handledTags)) {
+                    $handledTags[] = $cacheTag;
+                    $this->purgeIndividualFilesByCacheTag([$cacheTag]);
+                }
+            } elseif ($enablePurgeByUrl) {
+                $pageUid = (int)$params['cacheCmd'];
+                if ($pageUid && !in_array($pageUid, $handledPageUids)) {
+                    $handledPageUids[] = $pageUid;
+                    $this->clearPagesCache([$pageUid]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Clears the Cloudflare cache.
+     *
+     * @return void
+     */
+    public function clearCloudflareCache()
+    {
+        /** @var CloudflareService $cloudflareService */
+        $cloudflareService = GeneralUtility::makeInstance(CloudflareService::class, $this->config);
+
+        foreach ($this->domains as $domain) {
+            try {
+                list($identifier, $zoneName) = explode('|', $domain, 2);
+                $ret = $cloudflareService->send(
+                    '/zones/' . $identifier . '/purge_cache',
+                    [
+                        'purge_everything' => true,
+                    ],
+                    'DELETE'
+                );
+                if (!is_array($ret)) {
+                    $ret = [
+                        'success' => false,
+                        'errors' => []
+                    ];
+                }
+
+                if ($ret['success']) {
+                    $this->writelog(
+                        0,
+                        'User %s cleared the cache on Cloudflare (domain: "%s")',
+                        [$this->beUser->user['username'], $zoneName]
+                    );
+                } else {
+                    $this->writelog(
+                        1,
+                        'User %s failed to clear the cache on Cloudflare (domain: "%s"): %s',
+                        [$this->beUser->user['username'], $zoneName, implode(LF, $ret['errors'])]
+                    );
+                }
+            } catch (\RuntimeException $e) {
+                $this->writelog(1, $e->getMessage(), []);
+            }
+        }
+    }
+
+    /**
+     * Returns a Frontend URL corresponding to a given page UID.
+     * Implementation was inspired by EXT:vara_feurlfrombe
+     *
+     * @param array $uids
+     */
+    public function clearPagesCache(array $uids)
+    {
+        $groupedByDomain = [];
+
+        // Group all pages by root line
+        foreach ($uids as $uid) {
+            $domain = BackendUtility::firstDomainRecord(
+                BackendUtility::BEgetRootLine($uid)
+            );
+            if ($domain === null) {
+                $domain = GeneralUtility::getIndpEnv('HTTP_HOST');
+            }
+
+            if (!is_array($groupedByDomain[$domain])) {
+                $groupedByDomain[$domain] = [
+                    'uids' => [],
+                    'urls' => [],
+                    'zoneIdentifier' => $this->determinateDomainZoneIdentifier($domain)
+                ];
+            }
+            $groupedByDomain[$domain]['uids'][] = $uid;
+        }
+
+        // Get pages URLs using EID
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        foreach ($groupedByDomain as $domain => $domainGroup) {
+            if (empty($domainGroup['zoneIdentifier'])) {
+                unset($groupedByDomain[$domain]);
+                continue;
+            }
+            $data = [
+                'uids' => implode(',', $domainGroup['uids'])
+            ];
+            $eidUrl = sprintf(
+                '%s://%s/index.php?eID=%s&data=%s',
+                $scheme,
+                $domain,
+                ConfigurationUtility::EXT_KEY,
+                base64_encode(json_encode($data))
+            );
+            $headers = [
+                'Cookie: fe_typo_user=' . $_COOKIE['fe_typo_user']
+            ];
+            $result = json_decode(GeneralUtility::getURL($eidUrl, false, $headers), true);
+
+            if (is_array($result)) {
+                $groupedByDomain[$domain]['urls'] = $result;
+            }
+        }
+
+        // Purge cache on cloud flare
+        foreach ($groupedByDomain as $domain => $domainGroup) {
+            $urlsGroup = [];
+            $i = 0;
+            foreach ($domainGroup['urls'] as $url) {
+                $i++;
+                $urlsGroup[] = $url;
+                // Cloudflare has limit for clear files at once
+                if ($i === self::CLEAR_CACHE_URLS_LIMIT) {
+                    $this->purgeIndividualFilesByUrl(
+                        $urlsGroup,
+                        $domain,
+                        $domainGroup['uids'],
+                        $domainGroup['zoneIdentifier']
+                    );
+                    $i = 0;
+                    $urlsGroup = [];
+                }
+            }
+        }
+    }
+
+    /**
+     * Get zone identifier for domain
+     *
+     * @param string $domain
+     * @return null
+     */
+    protected function determinateDomainZoneIdentifier($domain)
+    {
+        foreach ($this->domains as $cdnDomain) {
+            list($identifier, $z) = explode('|', $cdnDomain, 2);
+            if ($z === $domain) {
+                return $identifier;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Granularly removes an individual file from Cloudflare's cache by specifying the URL.
+     *
+     * @param array $urls
+     * @param string $domain
+     * @param array $pageUids
+     * @param string $zoneIdentifier
+     * @return void
+     */
+    protected function purgeIndividualFilesByUrl(array $urls, $domain, array $pageUids, $zoneIdentifier)
+    {
+        /** @var CloudflareService $cloudflareService */
+        $cloudflareService = GeneralUtility::makeInstance(CloudflareService::class, $this->config);
+
+        try {
+            $ret = $cloudflareService->send(
+                '/zones/' . $zoneIdentifier . '/purge_cache',
+                [
+                    'files' => $urls,
+                ],
+                'DELETE'
+            );
+
+            if ($ret['result'] === 'error') {
+                $this->writelog(
+                    1,
+                    'User %s failed to clear the cache on Cloudflare (domain: "%s") for pages "%s": %s',
+                    [$this->beUser->user['username'], $domain, implode(',', $pageUids), $ret['msg']]
+                );
+            } else {
+                $this->writelog(
+                    0,
+                    'User %s cleared the cache on Cloudflare (domain: "%s") for pages "%s"',
+                    [$this->beUser->user['username'], $domain, implode(',', $pageUids)]
+                );
+            }
+        } catch (\RuntimeException $e) {
+            $this->writelog(1, $e->getMessage(), []);
+        }
+    }
+
+    /**
+     * Granularly removes an individual file from Cloudflare's cache by specifying the associated Cache-Tag.
+     *
+     * @param array $cacheTags
+     * @return void
+     */
+    protected function purgeIndividualFilesByCacheTag(array $cacheTags)
+    {
+        /** @var CloudflareService $cloudflareService */
+        $cloudflareService = GeneralUtility::makeInstance(CloudflareService::class, $this->config);
+
+        foreach ($this->domains as $domain) {
+            try {
+                list($identifier, $zoneName) = explode('|', $domain, 2);
+                $ret = $cloudflareService->send(
+                    '/zones/' . $identifier . '/purge_cache',
+                    [
+                        'tags' => $cacheTags,
+                    ],
+                    'DELETE'
+                );
+                if (!is_array($ret)) {
+                    $ret = [
+                        'success' => false,
+                        'errors' => []
+                    ];
+                }
+
+
+                if ($ret['success']) {
+                    $this->writelog(
+                        0,
+                        'User %s cleared the cache on Cloudflare using Cache-Tag (domain: "%s")',
+                        [$this->beUser->user['username'], $zoneName]
+                    );
+                } else {
+                    $this->writelog(
+                        1,
+                        'User %s failed to clear the cache on Cloudflare using Cache-Tag (domain: "%s"): %s',
+                        [$this->beUser->user['username'], $zoneName, implode(LF, $ret['errors'])]
+                    );
+                }
+            } catch (\RuntimeException $e) {
+                $this->writelog(1, $e->getMessage(), []);
+            }
+        }
+    }
+
+    /**
+     * Write log wrapper
+     *
+     * @param $error
+     * @param $message
+     * @param array $arguments
+     */
+    protected function writelog($error, $message, array $arguments)
+    {
+        if ($this->beUser !== null) {
+            /** @noinspection PhpParamsInspection */
+            $this->beUser->writelog(
+                4,
+                1,
+                $error,
+                0,
+                $message,
+                $arguments
+            );
+        }
+    }
+}

--- a/Classes/Services/ClearCacheService.php
+++ b/Classes/Services/ClearCacheService.php
@@ -237,10 +237,17 @@ class ClearCacheService
      */
     protected function determinateDomainZoneIdentifier($domain)
     {
-        foreach ($this->domains as $cdnDomain) {
-            list($identifier, $z) = explode('|', $cdnDomain, 2);
-            if ($z === $domain) {
-                return $identifier;
+        $domainParts = explode('.', $domain);
+        $size = count($domainParts);
+
+        if ($size > 1) {
+            $zoneName = $domainParts[$size - 2] . '.' . $domainParts[$size - 1];
+
+            foreach ($this->domains as $cdnDomain) {
+                list($identifier, $z) = explode('|', $cdnDomain, 2);
+                if ($z === $zoneName) {
+                    return $identifier;
+                }
             }
         }
 

--- a/Classes/Services/ClearCacheService.php
+++ b/Classes/Services/ClearCacheService.php
@@ -199,7 +199,7 @@ class ClearCacheService
             $result = json_decode(GeneralUtility::getURL($eidUrl, false, $headers), true);
 
             if (is_array($result)) {
-                $groupedByDomain[$domain]['urls'] = $result;
+                $groupedByDomain[$domain]['urls'] = $this->formatUrls($result);
             }
         }
 
@@ -341,6 +341,26 @@ class ClearCacheService
                 $this->writelog(1, $e->getMessage(), []);
             }
         }
+    }
+
+    /**
+     * Flush each url with and without ending "/"
+     * "host/url/" and "host/url" is different urls for cloudflare
+     *
+     * @param array $urls
+     * @return array
+     */
+    protected function formatUrls(array $urls)
+    {
+        $formattedUrls = [];
+
+        foreach ($urls as $url) {
+            $url = rtrim($url, '/');
+            $formattedUrls[] = $url;
+            $formattedUrls[] = $url . '/';
+        }
+
+        return $formattedUrls;
     }
 
     /**

--- a/Classes/Services/PagePathResolverService.php
+++ b/Classes/Services/PagePathResolverService.php
@@ -100,13 +100,13 @@ class PagePathResolverService
             $this->pageUids[0],
             ''
         );
+        $GLOBALS['TSFE'] = $tsfe;
+
         $tsfe->connectToDB();
         $tsfe->initFEuser();
         $tsfe->determineId();
         $tsfe->initTemplate();
         $tsfe->getConfigArray();
-
-        $GLOBALS['TSFE'] = $tsfe;
 
         // Set linkVars, absRefPrefix, etc
         PageGenerator::pagegenInit();

--- a/Classes/Services/PagePathResolverService.php
+++ b/Classes/Services/PagePathResolverService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Causal\Cloudflare\Services;
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Page\PageGenerator;
+use TYPO3\CMS\Frontend\Utility\EidUtility;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with TYPO3 source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Class PagePathResolverService
+ * @package Causal\Cloudflare\Services
+ */
+class PagePathResolverService
+{
+    /**
+     * Array of pages
+     * Assume that all pages are in one root line
+     *
+     * @var array
+     */
+    protected $pageUids = [];
+
+    /**
+     * Initializes variables for link
+     */
+    public function __construct()
+    {
+        $params = json_decode(base64_decode(GeneralUtility::_GP('data')), true);
+
+        if (is_array($params)) {
+            $this->pageUids = GeneralUtility::intExplode(',', $params['uids'], true);
+        }
+
+        EidUtility::initTCA();
+    }
+
+    /**
+     * Generate link
+     *
+     * @return string
+     */
+    public function getLinks()
+    {
+        $result = [];
+        if ($this->pageUids) {
+            $this->createTSFE();
+
+            /** @var ContentObjectRenderer $cObj */
+            $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+
+            foreach ($this->pageUids as $pageId) {
+                $typoLinkConf = [
+                    'parameter' => $pageId,
+                    'forceAbsoluteUrl' => 1
+                ];
+
+                $url = $cObj->typoLink_URL($typoLinkConf);
+                if (!empty($url)) {
+                    $host = parse_url($url, PHP_URL_HOST);
+                    $result[$pageId] = $host ? $url : GeneralUtility::locationHeaderUrl($url);
+                }
+            }
+        }
+
+        return json_encode($result);
+    }
+
+    /**
+     * Initializes TSFE. This is necessary to have proper environment for typoLink.
+     *
+     * @return void
+     */
+    protected function createTSFE()
+    {
+        /** @var TypoScriptFrontendController $tsfe */
+        $tsfe = GeneralUtility::makeInstance(
+            TypoScriptFrontendController::class,
+            $GLOBALS['TYPO3_CONF_VARS'],
+            $this->pageUids[0],
+            ''
+        );
+        $tsfe->connectToDB();
+        $tsfe->initFEuser();
+        $tsfe->determineId();
+        $tsfe->initTemplate();
+        $tsfe->getConfigArray();
+
+        $GLOBALS['TSFE'] = $tsfe;
+
+        // Set linkVars, absRefPrefix, etc
+        PageGenerator::pagegenInit();
+    }
+}

--- a/Classes/Services/PagePathResolverService.php
+++ b/Classes/Services/PagePathResolverService.php
@@ -70,7 +70,7 @@ class PagePathResolverService
                 foreach ($languages as $languageUid) {
                     $typoLinkConf = [
                         'parameter' => $pageId,
-                        'additionalParams' => '&L=' . $languageUid,
+                        'additionalParams' => $languageUid > 0 ? ('&L=' . $languageUid) : '',
                         'forceAbsoluteUrl' => 1
                     ];
 

--- a/Classes/Services/PurgeCacheQueueService.php
+++ b/Classes/Services/PurgeCacheQueueService.php
@@ -1,0 +1,100 @@
+<?php
+namespace Causal\Cloudflare\Services;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with TYPO3 source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Causal\Cloudflare\Domain\Model\QueueItem;
+use Causal\Cloudflare\Domain\Repository\QueueItemRepository;
+use Causal\Cloudflare\Utility\ConfigurationUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+/**
+ * Class PurgeCacheQueueService
+ * @package Causal\Cloudflare\Services
+ */
+class PurgeCacheQueueService
+{
+    /**
+     * @var QueueItemRepository
+     */
+    protected $queueItemRepository = null;
+
+    /**
+     * Default constructor.
+     */
+    public function __construct()
+    {
+        $this->queueItemRepository = GeneralUtility::makeInstance(ObjectManager::class)
+            ->get(QueueItemRepository::class);
+    }
+
+    /**
+     * Clear queue and request purge from cloudflare
+     */
+    public function purgeCacheQueue()
+    {
+        $queueItems = $this->queueItemRepository->findAll();
+        $clearAllCache = false;
+        $clearPageUids = [];
+        $clearCacheTags = [];
+
+        /** @var QueueItem $queueItem */
+        foreach ($queueItems as $queueItem) {
+            switch ($queueItem->getCacheCommand()) {
+                // Clear all
+                case QueueItem::CLEAR_CACHE_COMMAND_ALL:
+                    // If clear all caches no sense to do anything else
+                    $clearAllCache = true;
+                    break 2;
+                // Clear by tag
+                case QueueItem::CLEAR_CACHE_COMMAND_CACHE_TAG:
+                    $clearCacheTags[] = $queueItem->getCacheTag();
+                    break;
+                // Clear page
+                case QueueItem::CLEAR_CACHE_COMMAND_PAGE:
+                    $clearPageUids[] = $queueItem->getPageUid();
+                    break;
+                // No default action
+            }
+        }
+
+        $clearCacheService = $this->getClearCacheService();
+
+        if ($clearAllCache) {
+            $clearCacheService->clearCloudflareCache();
+        } else {
+            if (!empty($clearCacheTags)) {
+                $clearCacheService->clearCacheTags(array_unique($clearCacheTags));
+            }
+            if (!empty($clearPageUids)) {
+                $clearCacheService->clearPagesCache(array_unique($clearPageUids));
+            }
+        }
+
+        $this->queueItemRepository->removeQueueItems($queueItems);
+    }
+
+    /**
+     * @return ClearCacheService|object
+     */
+    protected function getClearCacheService()
+    {
+        return GeneralUtility::makeInstance(
+            ClearCacheService::class,
+            ConfigurationUtility::getExtensionConfiguration(),
+            $GLOBALS['BE_USER']
+        );
+    }
+}

--- a/Classes/Services/PurgeCacheQueueService.php
+++ b/Classes/Services/PurgeCacheQueueService.php
@@ -86,7 +86,7 @@ class PurgeCacheQueueService
                 $clearCacheService->clearPagesCache(array_unique($clearPageUids));
             }
             if (!empty($clearRootLinePageUids)) {
-                $clearCacheService->clearSitesRootLineCache($clearRootLinePageUids);
+                $clearCacheService->clearSitesRootLineCache(array_unique($clearRootLinePageUids));
             }
         }
 

--- a/Classes/Services/PurgeCacheQueueService.php
+++ b/Classes/Services/PurgeCacheQueueService.php
@@ -49,6 +49,7 @@ class PurgeCacheQueueService
         $clearAllCache = false;
         $clearPageUids = [];
         $clearCacheTags = [];
+        $clearRootLinePageUids = [];
 
         /** @var QueueItem $queueItem */
         foreach ($queueItems as $queueItem) {
@@ -66,6 +67,9 @@ class PurgeCacheQueueService
                 case QueueItem::CLEAR_CACHE_COMMAND_PAGE:
                     $clearPageUids[] = $queueItem->getPageUid();
                     break;
+                case QueueItem::CLEAR_CACHE_ROOT_LINE:
+                    $clearRootLinePageUids[] = $queueItem->getPageUid();
+                    break;
                 // No default action
             }
         }
@@ -80,6 +84,9 @@ class PurgeCacheQueueService
             }
             if (!empty($clearPageUids)) {
                 $clearCacheService->clearPagesCache(array_unique($clearPageUids));
+            }
+            if (!empty($clearRootLinePageUids)) {
+                $clearCacheService->clearSitesRootLineCache($clearRootLinePageUids);
             }
         }
 

--- a/Classes/Solr/AbstractDataUrlModifier.php
+++ b/Classes/Solr/AbstractDataUrlModifier.php
@@ -17,19 +17,6 @@ abstract class AbstractDataUrlModifier
     protected static $cloudFlareDomainsCache = [];
 
     /**
-     * @var int
-     */
-    protected $time = 0;
-
-    /**
-     * Initialize
-     */
-    public function __construct()
-    {
-        $this->time = time();
-    }
-
-    /**
      * Add time parameter to request
      *
      * @param string $pageUrl
@@ -39,7 +26,7 @@ abstract class AbstractDataUrlModifier
     public function modifyDataUrl($pageUrl, array $urlData)
     {
         if ($this->isCloudflareDomain($urlData['host'])) {
-            $pageUrl = rtrim($pageUrl, '&') . '&_=' . $this->time;
+            $pageUrl = rtrim($pageUrl, '&') . '&_=' . time();
         }
 
         return $pageUrl;

--- a/Classes/Solr/AbstractDataUrlModifier.php
+++ b/Classes/Solr/AbstractDataUrlModifier.php
@@ -26,7 +26,7 @@ abstract class AbstractDataUrlModifier
     public function modifyDataUrl($pageUrl, array $urlData)
     {
         if ($this->isCloudflareDomain($urlData['host'])) {
-            $pageUrl = rtrim($pageUrl, '&') . '&_=' . time();
+            $pageUrl = rtrim($pageUrl, '&') . '&_=' . microtime(true);
         }
 
         return $pageUrl;

--- a/Classes/Solr/AbstractDataUrlModifier.php
+++ b/Classes/Solr/AbstractDataUrlModifier.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace Causal\Cloudflare\Solr;
+
 use Causal\Cloudflare\Utility\ConfigurationUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -9,6 +11,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 abstract class AbstractDataUrlModifier
 {
+    const GET_PARAM_NAME = '_cf';
+
     /**
      * Cloudflare domains
      *
@@ -25,8 +29,10 @@ abstract class AbstractDataUrlModifier
      */
     public function modifyDataUrl($pageUrl, array $urlData)
     {
+        list($microsec, $sec) = explode(' ', microtime());
+
         if ($this->isCloudflareDomain($urlData['host'])) {
-            $pageUrl = rtrim($pageUrl, '&') . '&_=' . microtime(true);
+            $pageUrl = rtrim($pageUrl, '&') . '&' . self::GET_PARAM_NAME . '=' . $sec . $microsec;
         }
 
         return $pageUrl;

--- a/Classes/Solr/DataUrlModifier.php
+++ b/Classes/Solr/DataUrlModifier.php
@@ -1,0 +1,14 @@
+<?php
+namespace Causal\Cloudflare\Solr;
+
+use ApacheSolrForTypo3\Solr\IndexQueue\PageIndexerDataUrlModifier;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Solr url modifier
+ *
+ * @package Causal\Cloudflare\Solr
+ */
+class DataUrlModifier extends AbstractDataUrlModifier implements PageIndexerDataUrlModifier, SingletonInterface
+{
+}

--- a/Classes/Solr/DataUrlModifierBackwardCompatibility.php
+++ b/Classes/Solr/DataUrlModifierBackwardCompatibility.php
@@ -1,11 +1,12 @@
 <?php
 namespace Causal\Cloudflare\Solr;
+use TYPO3\CMS\Core\SingletonInterface;
 
 /**
  * Class DataUrlModifierBackwardCompatibility
  *
  * @package Causal\Cloudflare\Solr
  */
-class DataUrlModifierBackwardCompatibility extends AbstractDataUrlModifier implements \Tx_Solr_IndexQueuePageIndexerDataUrlModifier
+class DataUrlModifierBackwardCompatibility extends AbstractDataUrlModifier implements \Tx_Solr_IndexQueuePageIndexerDataUrlModifier, SingletonInterface
 {
 }

--- a/Classes/Solr/DataUrlModifierBackwardCompatibility.php
+++ b/Classes/Solr/DataUrlModifierBackwardCompatibility.php
@@ -1,0 +1,11 @@
+<?php
+namespace Causal\Cloudflare\Solr;
+
+/**
+ * Class DataUrlModifierBackwardCompatibility
+ *
+ * @package Causal\Cloudflare\Solr
+ */
+class DataUrlModifierBackwardCompatibility extends AbstractDataUrlModifier implements \Tx_Solr_IndexQueuePageIndexerDataUrlModifier
+{
+}

--- a/Classes/Task/ClearCacheTask.php
+++ b/Classes/Task/ClearCacheTask.php
@@ -1,0 +1,38 @@
+<?php
+namespace Causal\Cloudflare\Task;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with TYPO3 source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Causal\Cloudflare\Services\PurgeCacheQueueService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
+
+/**
+ * Class ClearCacheTask
+ * @package Causal\Cloudflare\Task
+ */
+class ClearCacheTask extends AbstractTask
+{
+    /**
+     * @return boolean
+     */
+    public function execute()
+    {
+        /** @var PurgeCacheQueueService $purgeCacheQueueService */
+        $purgeCacheQueueService = GeneralUtility::makeInstance(PurgeCacheQueueService::class);
+        $purgeCacheQueueService->purgeCacheQueue();
+
+        return true;
+    }
+}

--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -69,4 +69,36 @@ class ConfigurationUtility
 
         return isset($config['clearCacheMode']) && (int)$config['clearCacheMode'] === self::MODE_ON_FLY;
     }
+
+    /**
+     * Check if purge by tags is enabled
+     *
+     * @return bool
+     */
+    public static function isEnablePurgeByTags()
+    {
+        static $enablePurgeByTags;
+        if ($enablePurgeByTags === null) {
+            $enablePurgeByTags = isset(self::getExtensionConfiguration()['enablePurgeByTags'])
+                && (bool)self::getExtensionConfiguration()['enablePurgeByTags'];
+        }
+
+        return $enablePurgeByTags;
+    }
+
+    /**
+     * Check if purge by urls is enabled
+     *
+     * @return bool
+     */
+    public static function isEnablePurgeByUrl()
+    {
+        static $enablePurgeByUrl;
+        if ($enablePurgeByUrl === null) {
+            $enablePurgeByUrl = isset(self::getExtensionConfiguration()['enablePurgeSingleFile'])
+                && (bool)self::getExtensionConfiguration()['enablePurgeSingleFile'];
+        }
+
+        return $enablePurgeByUrl;
+    }
 }

--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -1,0 +1,72 @@
+<?php
+namespace Causal\Cloudflare\Utility;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with TYPO3 source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * Class ConfigurationUtility
+ * @package Causal\Cloudflare\Utility
+ */
+class ConfigurationUtility
+{
+    /**
+     * Extension key
+     */
+    const EXT_KEY = 'cloudflare';
+
+    /**
+     * Clear cache mode on fly
+     */
+    const MODE_ON_FLY = 1;
+
+    /**
+     * Clear cache mode scheduler
+     */
+    const MODE_SCHEDULER = 2;
+
+    /**
+     * Extension configuration
+     *
+     * @var array
+     */
+    protected static $extensionConfiguration = null;
+
+    /**
+     * Get extension configuration
+     *
+     * @return array
+     */
+    public static function getExtensionConfiguration()
+    {
+        if (self::$extensionConfiguration === null) {
+            self::$extensionConfiguration = unserialize(
+                $GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][self::EXT_KEY] ?: ''
+            );
+        }
+
+        return self::$extensionConfiguration ?: [];
+    }
+
+    /**
+     * Check if clear cache is in mode fly
+     *
+     * @return bool
+     */
+    public static function isFlyMode()
+    {
+        $config = self::getExtensionConfiguration();
+
+        return isset($config['clearCacheMode']) && (int)$config['clearCacheMode'] === self::MODE_ON_FLY;
+    }
+}

--- a/Configuration/TCA/tx_cloudflare_domain_model_queueitem.php
+++ b/Configuration/TCA/tx_cloudflare_domain_model_queueitem.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'ctrl' => [
+        'label' => 'cache_command',
+        'hideTable' => 1
+    ],
+    'columns' => [
+        'page_uid' => [
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int'
+            ]
+        ],
+        'cache_command' => [
+            'config' => [
+                'type' => 'input',
+                'eval' => 'int'
+            ]
+        ],
+        'cache_tag' => [
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim'
+            ]
+        ]
+    ]
+];

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -24,6 +24,9 @@
 			<trans-unit id="clear_cache">
 				<source>Clear Cloudflare cache</source>
 			</trans-unit>
+			<trans-unit id="clear_cache_description">
+			    <source>Purge Cloudflare CDN caches for all domains.</source>
+			</trans-unit>
 
 			<!-- dashboard -->
 			<trans-unit id="period.30">

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.0">
+	<file source-language="en" datatype="plaintext" original="messages" date="2014-12-30T17:07:23Z" product-name="cloudflare">
+		<header/>
+		<body>
+			<trans-unit id="scheduler.title">
+				<source>Cloudflare CDN clear cache</source>
+			</trans-unit>
+			<trans-unit id="scheduler.description">
+			    <source>Purge Cloudflare CDN cache items queue.</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -43,7 +43,7 @@
 				<source>On fly mode</source>
 			</trans-unit>
 			<trans-unit id="settings.labels.options.scheduler">
-				<source>Scheduler mode.</source>
+				<source>Scheduler mode</source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -33,6 +33,18 @@
 			<trans-unit id="settings.labels.zoneIdentifiers">
 				<source>Cloudflare API Zone Identifiers</source>
 			</trans-unit>
+			<trans-unit id="settings.labels.clearCacheCategory">
+				<source>Clear cache settings</source>
+			</trans-unit>
+			<trans-unit id="settings.labels.clearCacheMode">
+			    <source>Choose CDN clear cache mode: "On fly mode" - will try to clear cache instantly when cache is cleared in TYPO3. "Scheduler mode" - will enqueue clear cache command and run on next run of scheduler task.</source>
+			</trans-unit>
+			<trans-unit id="settings.labels.options.onFly">
+				<source>On fly mode</source>
+			</trans-unit>
+			<trans-unit id="settings.labels.options.scheduler">
+				<source>Scheduler mode.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -21,3 +21,6 @@ enablePurgeByTags = 0
 
 # customsubcategory=proxy=Proxy Settings; cat=advanced/proxy; type=string; label=LLL:EXT:cloudflare/Resources/Private/Language/locallang_db.xlf:settings.apiEndpoint
 apiEndpoint =
+
+# customsubcategory=clear_cache=LLL:EXT:cloudflare/Resources/Private/Language/locallang_db.xlf:settings.labels.clearCacheCategory; cat=advanced/clear_cache; type=options[LLL:EXT:cloudflare/Resources/Private/Language/locallang_db.xlf:settings.labels.options.onFly=1,LLL:EXT:cloudflare/Resources/Private/Language/locallang_db.xlf:settings.labels.options.scheduler=2]; label=LLL:EXT:cloudflare/Resources/Private/Language/locallang_db.xlf:settings.labels.clearCacheMode
+clearCacheMode = 1

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -113,6 +113,11 @@ $boot = function ($_EXTKEY) {
                 \Causal\Cloudflare\Solr\DataUrlModifier::class;
         }
     }
+    // Register typolink post processor
+    if (TYPO3_MODE === 'FE' && isset($_SERVER['HTTP_X_TX_SOLR_IQ'])) {
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typoLink_PostProc'][$_EXTKEY] =
+            \Causal\Cloudflare\Hooks\TypoLinkPostProcessor::class . '->processTypoLink';
+    }
 };
 
 $boot($_EXTKEY);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -112,11 +112,13 @@ $boot = function ($_EXTKEY) {
             $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier'] =
                 \Causal\Cloudflare\Solr\DataUrlModifier::class;
         }
-    }
-    // Register typolink post processor
-    if (TYPO3_MODE === 'FE' && isset($_SERVER['HTTP_X_TX_SOLR_IQ'])) {
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typoLink_PostProc'][$_EXTKEY] =
-            \Causal\Cloudflare\Hooks\TypoLinkPostProcessor::class . '->processTypoLink';
+
+        // Register typolink post processor
+        // If indexed page is shortcut it will redirect to cached page and cause request id mismatch
+        if (TYPO3_MODE === 'FE' && isset($_SERVER['HTTP_X_TX_SOLR_IQ'])) {
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typoLink_PostProc'][$_EXTKEY] =
+                \Causal\Cloudflare\Hooks\TypoLinkPostProcessor::class . '->processTypoLink';
+        }
     }
 };
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -93,8 +93,15 @@ $boot = function ($_EXTKEY) {
         }
     }
 
-    # Register EID
+    // Register EID
     $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include'][$_EXTKEY] = 'EXT:' . $_EXTKEY . '/Classes/Eid/LinkGeneratorEid.php';
+
+    // Register scheduler task
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\Causal\Cloudflare\Task\ClearCacheTask::class] = [
+        'extension' => $_EXTKEY,
+        'title' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_be.xlf:scheduler.title',
+        'description' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_be.xlf:scheduler.description',
+    ];
 };
 
 $boot($_EXTKEY);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,10 +2,7 @@
 defined('TYPO3_MODE') || die();
 
 $boot = function ($_EXTKEY) {
-    $config = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY]);
-    if (!is_array($config)) {
-        $config = [];
-    }
+    $config = \Causal\Cloudflare\Utility\ConfigurationUtility::getExtensionConfiguration();
 
     // Register additional clear_cache method
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = \Causal\Cloudflare\Hooks\TCEmain::class . '->clear_cacheCmd';
@@ -95,6 +92,9 @@ $boot = function ($_EXTKEY) {
             $GLOBALS['TYPO3_CONF_VARS']['BE']['AJAX']['cloudflare::clearCache'] = 'EXT:' . $_EXTKEY . '/Classes/Hooks/TCEmain.php:Causal\\Cloudflare\\Hooks\\TCEmain->clearCache';
         }
     }
+
+    # Register EID
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include'][$_EXTKEY] = 'EXT:' . $_EXTKEY . '/Classes/Eid/LinkGeneratorEid.php';
 };
 
 $boot($_EXTKEY);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -105,8 +105,9 @@ $boot = function ($_EXTKEY) {
 
     // Register URL modifier for solr to get parameter in page url. Otherwise it could get cached pages.
     if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('solr')) {
-        if (class_exists('Tx_Solr_IndexQueuePageIndexerDataUrlModifier')) {
-
+        if (@file_exists(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('solr') . 'Interfaces/IndexQueuePageIndexerDataUrlModifier.php')) {
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier'] =
+                \Causal\Cloudflare\Solr\DataUrlModifierBackwardCompatibility::class;
         } else {
             $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier'] =
                 \Causal\Cloudflare\Solr\DataUrlModifier::class;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -102,6 +102,16 @@ $boot = function ($_EXTKEY) {
         'title' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_be.xlf:scheduler.title',
         'description' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/locallang_be.xlf:scheduler.description',
     ];
+
+    // Register URL modifier for solr to get parameter in page url. Otherwise it could get cached pages.
+    if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('solr')) {
+        if (class_exists('Tx_Solr_IndexQueuePageIndexerDataUrlModifier')) {
+
+        } else {
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['IndexQueuePageIndexer']['dataUrlModifier'] =
+                \Causal\Cloudflare\Solr\DataUrlModifier::class;
+        }
+    }
 };
 
 $boot($_EXTKEY);

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,12 @@
+#
+# Table structure for table 'tx_cloudflare_domain_model_queueitem'
+#
+CREATE TABLE tx_cloudflare_domain_model_queueitem (
+	uid int(11) NOT NULL auto_increment,
+	crdate int(11) DEFAULT '0' NOT NULL,
+	page_uid int(11) DEFAULT '0' NOT NULL,
+	cache_command int(11) DEFAULT '0' NOT NULL,
+	cache_tag varchar(40) DEFAULT '' NOT NULL,
+
+	PRIMARY KEY (uid)
+) ENGINE=InnoDB;


### PR DESCRIPTION
1. Use EID to get FE urls for clear cdn cache by path. Support of language layers urls. Avoid errors connected with initialize FE environment on BE, like realurl decoder.
2. Added extension mode that allow to schedule CDN clear cache commands. Clear CDN cache on a fly may slow down BE. Can change mode in extension settings.
3. Fix cloudflare clear cache icon in TYPO3 8.7.