### PR TITLE
[FEATURE] Use Bearer Authentication (RFC 6750)

### DIFF
--- a/Documentation/AdministratorManual/Configuration/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/Index.rst
@@ -18,10 +18,12 @@ This extension comes with a few settings available from the Extension Manager.
 
 Category Basic
 ^^^^^^^^^^^^^^
-
-- **API Key** : This is the API key made available on your account page (https://www.cloudflare.com/a/account/my-account)
+- **Use Bearer Authentication** : Enables RFC 6750 Bearer Authentication. With this setting enabled, Email is no longer
+  a required field.
 
 - **Email** : The e-mail address associated with the API key.
+
+- **API Key** : This is the API key made available on your account page (https://www.cloudflare.com/a/account/my-account)
 
 - **Domains** : Once the API key and the email are successfully saved (be sure to click on "Update" button first), a
   list of domains (or zones in Cloudflare's terminology) handled by the corresponding account is rendered. Just tick the

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -3,6 +3,9 @@
 	<file source-language="en" datatype="plaintext" original="messages" date="2014-12-30T17:07:23Z" product-name="cloudflare">
 		<header/>
 		<body>
+			<trans-unit id="settings.useBearerAuthentication">
+				<source>Use Bearer Authentication (RFC 6750) and API key.</source>
+			</trans-unit>
 			<trans-unit id="settings.email">
 				<source>Email: The e-mail address associated with the API key.</source>
 			</trans-unit>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,3 +1,6 @@
+# cat=basic//05; type=boolean; label=LLL:EXT:cloudflare/Resources/Private/Language/locallang_db.xlf:settings.useBearerAuthentication
+useBearerAuthentication = 0
+
 # cat=basic//10; type=string; label=LLL:EXT:cloudflare/Resources/Private/Language/locallang_db.xlf:settings.email
 email =
 


### PR DESCRIPTION
Introduces the extension configuration option `useBearerAuthentication`, which switches authentication mode. https://blog.cloudflare.com/api-tokens-general-availability/